### PR TITLE
split name to get folder name if using specific extension versions

### DIFF
--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -4,10 +4,13 @@ define drush::extension() {
     fail('You must include class drush before declaring aliases')
   }
 
+  # split $name at the dash to eliminate the version component
+  $name_arr = split($name, '-')
+  $folder_name = $name_arr[0]
+
   exec {"${drush::drush_exe_default} dl ${name}":
-    creates => "/usr/share/drush/commands/${name}",
+    creates => "/usr/share/drush/commands/${folder_name}",
     notify  => Class['cacheclear'],
   }
 
 }
-


### PR DESCRIPTION
This will let you install modules with specific version numbers, provision-6.x-2.0, for example with idempodence. 