### PR TITLE
Support newer versions of concat

### DIFF
--- a/manifests/alias.pp
+++ b/manifests/alias.pp
@@ -1,4 +1,6 @@
-define drush::alias(
+# == Define Resource Type: drush::alias
+#
+define drush::alias (
   $ensure                  = present,
   $alias_name              = $name,
   $group                   = undef,

--- a/manifests/cacheclear.pp
+++ b/manifests/cacheclear.pp
@@ -1,3 +1,7 @@
+# == Class: drush::clearcache
+#
+# Private class.
+#
 class drush::cacheclear {
 
   #private()

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,3 +1,7 @@
+# == Class: drush::config
+#
+# Private class.
+#
 class drush::config {
 
   #private()

--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -1,3 +1,5 @@
+# == Define Resource Type: drush::extension
+#
 define drush::extension() {
 
   if (!defined(Class['drush'])) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,10 +81,10 @@ class drush(
   $install_base_path = '/opt/drush'
   $drush_exe_default = '/usr/local/bin/drush'
 
-  class{'drush::setup': } ->
-  class{'drush::config': } ~>
-  class{'drush::cacheclear': } ->
-  Class['drush']
+  class{'drush::setup': }
+  -> class{'drush::config': }
+  ~> class{'drush::cacheclear': }
+  -> Class['drush']
 
 }
 

--- a/manifests/install/composer.pp
+++ b/manifests/install/composer.pp
@@ -1,3 +1,5 @@
+# == Define Resource Type: drush::install::composer
+#
 define drush::install::composer(
   $autoupdate,
   $version,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,3 +1,7 @@
+# == Class: drush::params
+#
+# This class manages drush parameters.
+#
 class drush::params {
   case $::osfamily {
     'Debian': {

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -1,3 +1,7 @@
+# == Class: drush::setup
+#
+# Private class.
+#
 class drush::setup {
 
   #private()

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -24,7 +24,6 @@ module and should not be directly included in the manifest.")
     path   => '/etc/profile.d/drush.sh',
   }
   concat::fragment { 'drush-sh-profile-header':
-    ensure  => present,
     target  => 'drush-sh-profile',
     content => "# MANAGED BY PUPPET\n\n",
     order   => 0,
@@ -32,7 +31,6 @@ module and should not be directly included in the manifest.")
   if $drush::php_path {
     validate_absolute_path($drush::php_path)
     concat::fragment { 'drush-sh-profile-php-path':
-      ensure  => present,
       target  => 'drush-sh-profile',
       content => "export DRUSH_PHP=${drush::php_path}\n",
       order   => 1,
@@ -41,7 +39,6 @@ module and should not be directly included in the manifest.")
   if $drush::php_ini_path {
     validate_absolute_path($drush::php_ini_path)
     concat::fragment { 'drush-sh-profile-php-ini-path':
-      ensure  => present,
       target  => 'drush-sh-profile',
       content => "export PHP_INI=${drush::php_ini_path}\n",
       order   => 1,
@@ -50,7 +47,6 @@ module and should not be directly included in the manifest.")
   if $drush::drush_ini_path {
     validate_absolute_path($drush::drush_ini_path)
     concat::fragment { 'drush-sh-profile-drush-ini-path':
-      ensure  => present,
       target  => 'drush-sh-profile',
       content => "export DRUSH_INI=${drush::drush_ini_path}\n",
       order   => 1,


### PR DESCRIPTION
I've made a few 'linter' based updates, mostly amounting to docblocks at the tops of several of the definition types and classes. 

The only significant change is the removal of the deprecated and subsequently removed `ensure` property on `concat::fragement`. 


ref: https://github.com/puppetlabs/puppetlabs-concat/commit/ab0cf270e4967d9589f58b7c452ff24e870bb377#diff-07b462a4b4082856b785d62dee4f7468