### PR TITLE
Provide path to Exec resources

### DIFF
--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -11,7 +11,7 @@ define drush::extension() {
   $extension_name = $parts[0]
 
   exec {"${drush::drush_exe_default} dl ${name}":
-    command => "su - -c '${drush::drush_exe_default} dl ${name}'",
+    command => "/bin/su - -c '${drush::drush_exe_default} dl ${name}'",
     creates => "/usr/share/drush/commands/${extension_name}",
     notify  => Class['drush::cacheclear'],
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -59,7 +59,7 @@ define drush::install(
   }
 
   exec { "${drush}-first-run":
-    command     => "su - -c '${drush_exe} status'",
+    command     => "/bin/su - -c '${drush_exe} status'",
     require     => File[$drush_exe],
     refreshonly => true,
   }


### PR DESCRIPTION
It appears that newer versions of Puppet (I'm currently testing against 5.1.0), is more strictly testing that the commands given have absolute paths. I suspect this is fully compatible with users using either the future-parser or Puppet 4.x.