### PR TITLE
Use Puppet datatypes (5.5.0+) instead of the deprecated validate_*() functions

### DIFF
--- a/manifests/alias.pp
+++ b/manifests/alias.pp
@@ -1,39 +1,31 @@
 # == Define Resource Type: drush::alias
 #
 define drush::alias (
-  $ensure                  = present,
-  $alias_name              = $name,
-  $group                   = undef,
-  $parent                  = undef,
-  $root                    = undef,
-  $uri                     = undef,
-  $db_url                  = undef,
-  $path_aliases            = undef,
-  $ssh_options             = undef,
-  $remote_host             = undef,
-  $remote_user             = undef,
-  $custom_options          = undef,
-  $command_specific        = undef,
-  $source_command_specific = undef,
-  $target_command_specific = undef,
+  String $ensure                          = present,
+  String $alias_name                      = $name,
+  Optional[String] $group                 = undef,
+  Optional[String] $parent                = undef,
+  Optional[Stdlib::Absolutepath] $root    = undef,
+  Optional[String] $uri                   = undef,
+  Optional[String] $db_url                = undef,
+  Optional[Hash] $path_aliases            = undef,
+  Optional[String] $ssh_options           = undef,
+  Optional[String] $remote_host           = undef,
+  Optional[String] $remote_user           = undef,
+  Optional[Hash] $custom_options          = undef,
+  Optional[Hash] $command_specific        = undef,
+  Optional[Hash] $source_command_specific = undef,
+  Optional[Hash] $target_command_specific = undef,
 ) {
 
   if (!defined(Class['drush'])) {
     fail('You must include class drush before declaring aliases')
   }
 
-  if $root {
-    validate_absolute_path($root)
-  }
   if $parent {
-    validate_re($parent, '^@',
-    "Invalid parent alias '${parent}'. Parent aliases must start with @.")
-  }
-  if $custom_options {
-    validate_hash($custom_options)
-  }
-  if $command_specific {
-    validate_hash($command_specific)
+    if $parent !~ /^@/ {
+      fail("Invalid parent alias '${parent}'. Parent aliases must start with @.")
+    }
   }
 
   $aliasfile = $group ? {

--- a/manifests/aliasng.pp
+++ b/manifests/aliasng.pp
@@ -1,21 +1,21 @@
 # == Define Resource Type: drush::aliasng
 #
 define drush::aliasng (
-  $ensure                  = present,
-  $alias_name              = $name,
-  $group                   = undef,
-  $parent                  = undef,
-  $root                    = undef,
-  $uri                     = undef,
-  $db_url                  = undef,
-  $path_aliases            = undef,
-  $ssh_options             = undef,
-  $remote_host             = undef,
-  $remote_user             = undef,
-  $custom_options          = undef,
-  $command_specific        = undef,
-  $source_command_specific = undef,
-  $target_command_specific = undef,
+  String $ensure                          = present,
+  String $alias_name                      = $name,
+  Optional[String] $group                 = undef,
+  Optional[String] $parent                = undef,
+  Optional[Stdlib::Absolutepath] $root    = undef,
+  Optional[String] $uri                   = undef,
+  Optional[String] $db_url                = undef,
+  Optional[Hash] $path_aliases            = undef,
+  Optional[String] $ssh_options           = undef,
+  Optional[String] $remote_host           = undef,
+  Optional[String] $remote_user           = undef,
+  Optional[Hash] $custom_options          = undef,
+  Optional[Hash] $command_specific        = undef,
+  Optional[Hash] $source_command_specific = undef,
+  Optional[Hash] $target_command_specific = undef,
 ) {
 
   if (!defined(Class['drush'])) {
@@ -33,16 +33,6 @@ define drush::aliasng (
   }
   if $target_command_specific {
     warning("Drush versions >= 9 doesn't support 'target_command_specific' option. Ignoring.")
-  }
-
-  if $root {
-    validate_absolute_path($root)
-  }
-  if $custom_options {
-    validate_hash($custom_options)
-  }
-  if $command_specific {
-    validate_hash($command_specific)
   }
 
   $aliasfile = $group ? {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,9 +11,6 @@ module and should not be directly included in the manifest.")
   }
 
   # Bash integration and autocompletion based on the default version.
-  validate_bool($drush::bash_integration,
-                $drush::bash_autocompletion
-  )
   if $drush::bash_integration {
     file { '/etc/profile.d/drushrc.sh':
       ensure => link,
@@ -49,7 +46,6 @@ module and should not be directly included in the manifest.")
 
 
   # Create aliases.
-  validate_hash($drush::aliases)
   if $drush::legacy {
     create_resources(drush::alias, $drush::aliases)
   }
@@ -58,7 +54,6 @@ module and should not be directly included in the manifest.")
   }
 
   # Install extensions.
-  validate_array($drush::extensions)
   if $drush::legacy {
     drush::extension{ $drush::extensions: }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,23 +52,22 @@
 #   environment variable system-wide. See `docs-ini-files` for details.
 #
 class drush(
-  $versions              = ['10',],
-  $default_version       = '10',
-  $install_type          = 'dist',
-  $ensure_extra_packages = false,
-  $extra_packages        = $drush::params::extra_packages,
-  $bash_integration      = false,
-  $bash_autocompletion   = true,
-  $extensions            = [],
-  $aliases               = {},
-  $composer_path         = '/usr/local/bin/composer',
-  $php_path              = undef,
-  $php_ini_path          = undef,
-  $drush_ini_path        = undef,
+  Array[String] $versions                        = ['10',],
+  String $default_version                        = '10',
+  String $install_type                           = 'dist',
+  Boolean $ensure_extra_packages                 = false,
+  Array[String] $extra_packages                  = $drush::params::extra_packages,
+  Boolean $bash_integration                      = false,
+  Boolean $bash_autocompletion                   = true,
+  Array $extensions                              = [],
+  Hash $aliases                                  = {},
+  Stdlib::Absolutepath $composer_path            = '/usr/local/bin/composer',
+  Optional[Stdlib::Absolutepath] $php_path       = undef,
+  Optional[Stdlib::Absolutepath] $php_ini_path   = undef,
+  Optional[Stdlib::Absolutepath] $drush_ini_path = undef,
 ) inherits drush::params {
 
   # Identify legacy and/or modern drush installation.
-  validate_array($drush::versions)
   $legacy_versions = $drush::versions.filter |$version| {
     versioncmp($version, '9') < 0
   }
@@ -79,11 +78,8 @@ class drush(
   $modern = count($modern_versions) > 0
 
   # Pick default major version.
-  validate_string($default_version)
   $parts = split($default_version, '[.]')
   $default_version_major = $parts[0]
-
-  validate_absolute_path($composer_path)
 
   $install_base_path = '/opt/drush'
   $drush_exe_default = '/usr/local/bin/drush'

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -11,9 +11,7 @@ module and should not be directly included in the manifest.")
   }
 
   # Install extra packages.
-  validate_bool($drush::ensure_extra_packages)
   if $drush::ensure_extra_packages {
-    validate_array($drush::extra_packages)
     package { $drush::extra_packages:
       ensure => installed,
     }
@@ -29,7 +27,6 @@ module and should not be directly included in the manifest.")
     order   => 0,
   }
   if $drush::php_path {
-    validate_absolute_path($drush::php_path)
     concat::fragment { 'drush-sh-profile-php-path':
       target  => 'drush-sh-profile',
       content => "export DRUSH_PHP=${drush::php_path}\n",
@@ -37,7 +34,6 @@ module and should not be directly included in the manifest.")
     }
   }
   if $drush::php_ini_path {
-    validate_absolute_path($drush::php_ini_path)
     concat::fragment { 'drush-sh-profile-php-ini-path':
       target  => 'drush-sh-profile',
       content => "export PHP_INI=${drush::php_ini_path}\n",
@@ -45,7 +41,6 @@ module and should not be directly included in the manifest.")
     }
   }
   if $drush::drush_ini_path {
-    validate_absolute_path($drush::drush_ini_path)
     concat::fragment { 'drush-sh-profile-drush-ini-path':
       target  => 'drush-sh-profile',
       content => "export DRUSH_INI=${drush::drush_ini_path}\n",

--- a/metadata.json
+++ b/metadata.json
@@ -50,7 +50,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 7.0.0"
+      "version_requirement": ">= 5.5.0 < 8.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
Fixes #15.